### PR TITLE
AppOps: fix deadlock issue when showing dialog

### DIFF
--- a/services/core/java/com/android/server/AppOpsService.java
+++ b/services/core/java/com/android/server/AppOpsService.java
@@ -1490,15 +1490,18 @@ public class AppOpsService extends IAppOpsService.Stub {
 
         @Override
         public void run() {
+            PermissionDialog permDialog = null;
             synchronized (AppOpsService.this) {
                 Log.e(TAG, "Creating dialog box");
                 op.dialogReqQueue.register(request);
                 if (op.dialogReqQueue.getDialog() == null) {
-                    Dialog d = new PermissionDialog(mContext,
+                    permDialog = new PermissionDialog(mContext,
                             AppOpsService.this, code, uid, packageName);
-                    op.dialogReqQueue.setDialog((PermissionDialog)d);
-                    d.show();
+                    op.dialogReqQueue.setDialog(permDialog);
                 }
+            }
+            if (permDialog != null) {
+                permDialog.show();
             }
         }
     }


### PR DESCRIPTION
WindowManagerService need call PowerManagerService to release
wakelock. The Notifier in PowerManagerService need call AppOpsService
to notify holding wakelock ops is finished.  Meanwhile, AppOpsService
may need call WindowManagerService to show dialog. This scenario
will lead to deadlock issue.
To move showing dialog action out of lock section to fix this issue.
Since only UI work is moved out of lock area, it is supposed to be
safe.

Change-Id: I3f2bf4b9c9d81914cfd3c0fc3fc76d0b4a06a1f6
CRs-fixed: 786466