### PR TITLE
systemui: Underp blur effect after theme change

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBarKeyguardViewManager.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBarKeyguardViewManager.java
@@ -159,6 +159,7 @@ public class StatusBarKeyguardViewManager {
     public void onScreenTurnedOn(final IKeyguardShowCallback callback) {
         mScreenOn = true;
         mPhoneStatusBar.onScreenTurnedOn();
+        mStatusBarWindowManager.onKeyguardChanged();
         if (callback != null) {
             callbackAfterDraw(callback);
         }


### PR DESCRIPTION
 * We still need to apply the blur when the screen is toggled, otherwise
   it might get removed forever. Easy repro is to change statusbar
   theme then observe the lack of blur.

Change-Id: I69c6760549168583cd8176909346f0c873befb51