### PR TITLE
Revert "Boot up optimization for phoneprocess"

### DIFF
--- a/services/core/java/com/android/server/MmsServiceBroker.java
+++ b/services/core/java/com/android/server/MmsServiceBroker.java
@@ -118,7 +118,7 @@ public class MmsServiceBroker extends SystemService {
     }
 
     public void systemRunning() {
-        Slog.i(TAG, "systemRunning");
+        tryConnecting();
     }
 
     private void tryConnecting() {


### PR DESCRIPTION
Most likely culprit of "No Service and Signal bar out of sync" lockscreen issue. 

This reverts commit f3bc49665079e82fae42dda56c684d11b9071482.

Change-Id: Id4e9edcf7d931c59e0d180aa59f11761ee6d3f89