### PR TITLE
systemui: animate clear recents exit

### DIFF
--- a/packages/SystemUI/res/values/config.xml
+++ b/packages/SystemUI/res/values/config.xml
@@ -197,7 +197,7 @@
     <!-- The min animation duration for animating the nav bar scrim in. -->
     <integer name="recents_nav_bar_scrim_enter_duration">400</integer>
     <!-- The animation duration for animating the removal of a task view. -->
-    <integer name="recents_animate_task_view_remove_duration">250</integer>
+    <integer name="recents_animate_task_view_remove_duration">450</integer>
     <!-- The animation duration for scrolling the stack to a particular item. -->
     <integer name="recents_animate_task_stack_scroll_duration">225</integer>
     <!-- The minimum alpha for the dim applied to cards that go deeper into the stack. -->

--- a/packages/SystemUI/src/com/android/systemui/recents/views/RecentsView.java
+++ b/packages/SystemUI/src/com/android/systemui/recents/views/RecentsView.java
@@ -318,6 +318,26 @@ public class RecentsView extends FrameLayout implements TaskStackView.TaskStackV
         mClearRecents = ((View)getParent()).findViewById(R.id.clear_recents);
         mClearRecents.setOnClickListener(new View.OnClickListener() {
             public void onClick(View v) {
+                if (mClearRecents.getAlpha() != 1f) {
+                    return;
+                }
+
+                // Hide clear recents before dismiss all tasks
+                mClearRecents.animate()
+                    .alpha(0f)
+                    .setStartDelay(0)
+                    .setUpdateListener(null)
+                    .setInterpolator(mConfig.fastOutSlowInInterpolator)
+                    .setDuration(mConfig.taskViewRemoveAnimDuration)
+                    .withEndAction(new Runnable() {
+                        @Override
+                        public void run() {
+                            mClearRecents.setVisibility(View.GONE);
+                            mClearRecents.setAlpha(1f);
+                        }
+                    })
+                    .start();
+
                 dismissAllTasksAnimated();
             }
         });

--- a/packages/SystemUI/src/com/android/systemui/recents/views/TaskStackView.java
+++ b/packages/SystemUI/src/com/android/systemui/recents/views/TaskStackView.java
@@ -488,7 +488,7 @@ public class TaskStackView extends FrameLayout implements TaskStack.TaskStackCal
 
         Task t = mStack.getTasks().get(mFocusedTaskIndex);
         TaskView tv = getChildViewForTask(t);
-        tv.dismissTask();
+        tv.dismissTask(0L);
     }
 
     public void dismissAllTasks() {
@@ -499,11 +499,14 @@ public class TaskStackView extends FrameLayout implements TaskStack.TaskStackCal
                 tasks.addAll(mStack.getTasks());
 
                 // Remove visible TaskViews
+                long dismissDelay = 0;
                 int childCount = getChildCount();
+                int delay = mConfig.taskViewRemoveAnimDuration / childCount;
                 for (int i = 0; i < childCount; i++) {
                     TaskView tv = (TaskView) getChildAt(i);
                     tasks.remove(tv.getTask());
-                    tv.dismissTask();
+                    tv.dismissTask(dismissDelay);
+                    dismissDelay += delay;
                 }
 
                 int size = tasks.size();
@@ -1193,7 +1196,7 @@ public class TaskStackView extends FrameLayout implements TaskStack.TaskStackCal
                         public void run() {
                             mStack.removeTask(t);
                         }
-                    });
+                    }, 0L);
                 } else {
                     // Otherwise, remove the task from the stack immediately
                     mStack.removeTask(t);

--- a/packages/SystemUI/src/com/android/systemui/recents/views/TaskView.java
+++ b/packages/SystemUI/src/com/android/systemui/recents/views/TaskView.java
@@ -524,16 +524,16 @@ public class TaskView extends FrameLayout implements Task.TaskCallbacks,
     }
 
     /** Animates the deletion of this task view */
-    void startDeleteTaskAnimation(final Runnable r) {
+    void startDeleteTaskAnimation(final Runnable r, long delayed) {
         // Disabling clipping with the stack while the view is animating away
         setClipViewInStack(false);
 
         animate().translationX(mConfig.taskViewRemoveAnimTranslationXPx)
             .alpha(0f)
-            .setStartDelay(0)
+            .setStartDelay(delayed)
             .setUpdateListener(null)
             .setInterpolator(mConfig.fastOutSlowInInterpolator)
-            .setDuration(mConfig.taskViewRemoveAnimDuration)
+            .setDuration(mConfig.taskViewRemoveAnimDuration - delayed)
             .withEndAction(new Runnable() {
                 @Override
                 public void run() {
@@ -562,7 +562,7 @@ public class TaskView extends FrameLayout implements Task.TaskCallbacks,
     }
 
     /** Dismisses this task. */
-    void dismissTask() {
+    void dismissTask(long delayed) {
         // Animate out the view and call the callback
         final TaskView tv = this;
         startDeleteTaskAnimation(new Runnable() {
@@ -570,7 +570,7 @@ public class TaskView extends FrameLayout implements Task.TaskCallbacks,
             public void run() {
                 mCb.onTaskViewDismissed(tv);
             }
-        });
+        }, delayed);
         // Hide the footer
         animateFooterVisibility(false, mConfig.taskViewRemoveAnimDuration);
     }
@@ -869,7 +869,7 @@ public class TaskView extends FrameLayout implements Task.TaskCallbacks,
                     if (Constants.DebugFlags.App.EnableTaskFiltering && v == mHeaderView.mApplicationIcon) {
                         mCb.onTaskViewAppIconClicked(tv);
                     } else if (v == mHeaderView.mDismissButton) {
-                        dismissTask();
+                        dismissTask(0L);
                     }
                 }
             }, 125);


### PR DESCRIPTION
Currently, the animation just clear all the tasks at the same time. Just add
a delay between every task remove call, and hide clear recents before start
any animation.

Change-Id: Idbdeacc68c6519d28dc875d09cd75c71e2e9f701
Signed-off-by: Jorge Ruesga <jorge@ruesga.com>