### PR TITLE
Themes: Don't recreate network controllers

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
@@ -1092,7 +1092,9 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
         mSuController = new SuControllerImpl(mContext);
 
         if (isMSim()) {
-            mMSimNetworkController = new MSimNetworkControllerImpl(mContext);
+            if (mMSimNetworkController == null) {
+                mMSimNetworkController = new MSimNetworkControllerImpl(mContext);
+            }
             MSimSignalClusterView signalCluster = (MSimSignalClusterView)
                     mStatusBarView.findViewById(R.id.msim_signal_cluster);
             MSimSignalClusterView signalClusterKeyguard = (MSimSignalClusterView)
@@ -1130,7 +1132,9 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
                 //});
             }
         } else {
-            mNetworkController = new NetworkControllerImpl(mContext);
+            if (mNetworkController == null) {
+                mNetworkController = new NetworkControllerImpl(mContext);
+            }
             final SignalClusterView signalCluster =
                 (SignalClusterView)mStatusBarView.findViewById(R.id.signal_cluster);
             final SignalClusterView signalClusterKeyguard =
@@ -3740,9 +3744,9 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
         mRecreating = true;
 
         if (mMSimNetworkController != null) {
-            mContext.unregisterReceiver(mMSimNetworkController);
+            mMSimNetworkController.removeAllSignalClusters();
         } else if (mNetworkController != null) {
-            mContext.unregisterReceiver(mNetworkController);
+            mNetworkController.removeAllSignalClusters();
         }
 
         removeHeadsUpView();

--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/MSimNetworkControllerImpl.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/MSimNetworkControllerImpl.java
@@ -275,6 +275,11 @@ public class MSimNetworkControllerImpl extends NetworkControllerImpl {
         refreshSignalCluster(cluster, phoneId);
     }
 
+    @Override
+    public void removeAllSignalClusters() {
+        mSimSignalClusters.clear();
+    }
+
     public void refreshSignalCluster(MSimSignalCluster cluster, int phoneId) {
         cluster.setWifiIndicators(
                 // only show wifi in the cluster if connected or if wifi-only

--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/NetworkControllerImpl.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/NetworkControllerImpl.java
@@ -370,6 +370,10 @@ public class NetworkControllerImpl extends BroadcastReceiver
         refreshSignalCluster(cluster);
     }
 
+    public void removeAllSignalClusters() {
+        mSignalClusters.clear();
+    }
+
     public void addNetworkSignalChangedCallback(NetworkSignalChangedCallback cb) {
         mSignalsChangedCallbacks.add(cb);
         notifySignalsChangedCallbacks(cb);


### PR DESCRIPTION
When re-creating the network controllers we lose their current
state, which results in a bug on multi-sim devices where the first
sim slot will show the no connectivity icon rather than the no sim
icon when no sim is present.

Change-Id: I169734b1f5c7b17e11cc15a3434a22ed9f7bce1f
REF: TOMATOL-160