### PR TITLE
systemui: fix glitches with recents view and search widget

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/recents/RecentsActivity.java
+++ b/packages/SystemUI/src/com/android/systemui/recents/RecentsActivity.java
@@ -322,7 +322,7 @@ public class RecentsActivity extends Activity implements RecentsView.RecentsView
                         mSearchAppWidgetInfo);
                 Bundle opts = new Bundle();
                 opts.putInt(AppWidgetManager.OPTION_APPWIDGET_HOST_CATEGORY,
-                        AppWidgetProviderInfo.WIDGET_CATEGORY_SEARCHBOX);
+                        AppWidgetProviderInfo.WIDGET_CATEGORY_HOME_SCREEN);
                 mSearchAppWidgetHostView.updateAppWidgetOptions(opts);
                 // Set the padding to 0 for this search widget
                 mSearchAppWidgetHostView.setPadding(0, 0, 0, 0);

--- a/packages/SystemUI/src/com/android/systemui/recents/misc/SystemServicesProxy.java
+++ b/packages/SystemUI/src/com/android/systemui/recents/misc/SystemServicesProxy.java
@@ -430,7 +430,7 @@ public class SystemServicesProxy {
         int searchWidgetId = host.allocateAppWidgetId();
         Bundle opts = new Bundle();
         opts.putInt(AppWidgetManager.OPTION_APPWIDGET_HOST_CATEGORY,
-                AppWidgetProviderInfo.WIDGET_CATEGORY_SEARCHBOX);
+                AppWidgetProviderInfo.WIDGET_CATEGORY_HOME_SCREEN);
         if (!mAwm.bindAppWidgetIdIfAllowed(searchWidgetId, searchWidgetInfo.provider, opts)) {
             return null;
         }


### PR DESCRIPTION
Reduce the glitches causes by switchin between the recents view and the search activity (with text
and voice search). Force search widget (specially to QuickSearchBox) to view the recents activity
as a HOME_SCREEN widget category instead of a SEARCHBOX widget category.

Change-Id: I08157d7de8dab806b19d2f4a28f9843402d12179
Signed-off-by: Jorge Ruesga <jorge@ruesga.com>